### PR TITLE
Load local simulation module for PyScript star chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     </style>
     <py-config>
         packages = ["numpy"]
+        [[fetch]]
+        files = ["geocentric_sim.py"]
     </py-config>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Fetch local `geocentric_sim.py` module so PyScript star chart runs on GitHub Pages

## Testing
- `python geocentric_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba770a544c832fafb6c356298a6d56