### PR TITLE
Add geocentric solar system simulation with moon

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     <py-script>
 import numpy as np
 from js import document, requestAnimationFrame
-from solar_system import step, masses, positions, velocities, AU, SUN_IDX
+from solar_system import step, masses, positions, velocities, AU, EARTH_IDX
 
 canvas = document.getElementById("sky")
 ctx = canvas.getContext("2d")
@@ -30,24 +30,35 @@ pos = positions.copy()
 vel = velocities.copy()
 dt = 60 * 60  # one hour
 
-# Colour per body: Sun, Mercury, Venus, Earth, Mars
-colors = ["#ffff00", "#bebebe", "#e5c39b", "#00a2ff", "#ff4500"]
-orbit_radii = np.linalg.norm(positions - positions[SUN_IDX], axis=1)
+# Colour per body: Sun, Mercury, Venus, Earth, Moon, Mars
+colors = ["#ffff00", "#bebebe", "#e5c39b", "#00a2ff", "#bbbbbb", "#ff4500"]
+history = [[] for _ in masses]
+trail = 200
 
 
 def draw(*args):
-    global pos, vel
+    global pos, vel, history
     pos, vel = step(pos, vel, masses, dt)
-    rel = pos - pos[SUN_IDX]
+    rel = pos - pos[EARTH_IDX]
+    for i in range(len(masses)):
+        history[i].append(rel[i])
+        if len(history[i]) > trail:
+            history[i].pop(0)
     ctx.clearRect(0, 0, canvas.width, canvas.height)
 
-    # Draw orbital paths
-    for i, r in enumerate(orbit_radii):
-        if i == SUN_IDX:
+    # Draw trajectories
+    for i, track in enumerate(history):
+        if i == EARTH_IDX:
             continue
         ctx.beginPath()
-        ctx.arc(canvas.width/2, canvas.height/2, r*scale, 0, 2*np.pi)
-        ctx.strokeStyle = "#333"
+        for j, (x, y, z) in enumerate(track):
+            px = canvas.width / 2 + x * scale
+            py = canvas.height / 2 + y * scale
+            if j == 0:
+                ctx.moveTo(px, py)
+            else:
+                ctx.lineTo(px, py)
+        ctx.strokeStyle = colors[i]
         ctx.stroke()
 
     # Draw bodies
@@ -55,7 +66,7 @@ def draw(*args):
         px = canvas.width / 2 + x * scale
         py = canvas.height / 2 + y * scale
         ctx.beginPath()
-        ctx.arc(px, py, 8 if i == SUN_IDX else 4, 0, 2 * np.pi)
+        ctx.arc(px, py, 8 if i == EARTH_IDX else 4, 0, 2 * np.pi)
         ctx.fillStyle = colors[i]
         ctx.fill()
 

--- a/solar_system.py
+++ b/solar_system.py
@@ -21,25 +21,28 @@ AU = 1.495978707e11  # Astronomical unit (m)
 DAY = 86400.0
 
 
-# Masses (kg) of Sun, Mercury, Venus, Earth and Mars respectively
+# Masses (kg) of Sun, Mercury, Venus, Earth, Moon and Mars respectively
 SUN_IDX = 0
+EARTH_IDX = 3
 masses = np.array([
-    1.9885e30,  # Sun
-    3.3011e23,  # Mercury
-    4.8675e24,  # Venus
+    1.9885e30,   # Sun
+    3.3011e23,   # Mercury
+    4.8675e24,   # Venus
     5.97219e24,  # Earth
-    6.4171e23,  # Mars
+    7.34767309e22,  # Moon
+    6.4171e23,   # Mars
 ], dtype=np.float64)
 
 
 # Initial positions (m) in a heliocentric frame at t=0.
 # Earth starts on the positive x-axis; other planets are placed for demo.
 positions = np.array([
-    [0.0, 0.0, 0.0],            # Sun
-    [0.0, 0.387 * AU, 0.0],     # Mercury
-    [0.0, 0.723 * AU, 0.0],     # Venus
-    [AU, 0.0, 0.0],             # Earth
-    [0.0, 1.524 * AU, 0.0],     # Mars
+    [0.0, 0.0, 0.0],             # Sun
+    [0.0, 0.387 * AU, 0.0],      # Mercury
+    [0.0, 0.723 * AU, 0.0],      # Venus
+    [AU, 0.0, 0.0],              # Earth
+    [AU + 0.00257 * AU, 0.0, 0.0],  # Moon (approximate)
+    [0.0, 1.524 * AU, 0.0],      # Mars
 ], dtype=np.float64)
 
 
@@ -49,6 +52,7 @@ velocities = np.array([
     [np.sqrt(G * masses[SUN_IDX] / (0.387 * AU)), 0.0, 0.0],
     [np.sqrt(G * masses[SUN_IDX] / (0.723 * AU)), 0.0, 0.0],
     [0.0, np.sqrt(G * masses[SUN_IDX] / AU), 0.0],
+    [0.0, np.sqrt(G * masses[SUN_IDX] / AU) + np.sqrt(G * masses[EARTH_IDX] / (0.00257 * AU)), 0.0],
     [np.sqrt(G * masses[SUN_IDX] / (1.524 * AU)), 0.0, 0.0],
 ], dtype=np.float64)
 


### PR DESCRIPTION
## Summary
- Center simulation on Earth and render Sun, Moon, and nearby planets
- Add Moon mass, position and velocity to n-body model
- Draw planetary trajectories relative to Earth with trailing paths

## Testing
- `python -m py_compile solar_system.py`
- `python solar_system.py`

------
https://chatgpt.com/codex/tasks/task_e_68ba7999c010832f801b15bf8d994ee0