### PR TITLE
Randomize initial solar system time

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,8 @@
     });
 
     let astroTime = Astronomy.MakeTime(new Date());
+    const randomDays = (Math.random() - 0.5) * 365.25 * 200; // random offset up to ±100 years
+    astroTime = astroTime.AddDays(randomDays);
     let lastTime = performance.now();
 
     function draw(now) {


### PR DESCRIPTION
## Summary
- Randomize the simulation start date to give planets a random initial configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba818c002c832fabeb6b73d4ce0fbb