### PR TITLE
Add positive and negative emotion levels

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,31 +6,40 @@
   <style>
     body { background: #000; color: #fff; text-align: center; font-family: sans-serif; }
     canvas { background: #000; display: block; margin: 0 auto; }
-    #emotionBarContainer {
+    .emotionBarContainer {
       width: 300px;
       height: 20px;
       border: 1px solid #fff;
       margin: 20px auto;
     }
-    #emotionBar {
+    .emotionBar {
       height: 100%;
       width: 0%;
-      background: #ff69b4;
+    }
+    #positiveEmotionBar {
+      background: #32cd32;
+    }
+    #negativeEmotionBar {
+      background: #dc143c;
     }
   </style>
 </head>
 <body>
   <h1>Solar System</h1>
   <canvas id="solarSystem" width="600" height="600"></canvas>
-  <div>Emotion Level: <span id="emotionValue">0</span>%</div>
-  <div id="emotionBarContainer"><div id="emotionBar"></div></div>
+  <div>Positive Emotion Level: <span id="positiveEmotionValue">0</span>%</div>
+  <div id="positiveEmotionBarContainer" class="emotionBarContainer"><div id="positiveEmotionBar" class="emotionBar"></div></div>
+  <div>Negative Emotion Level: <span id="negativeEmotionValue">0</span>%</div>
+  <div id="negativeEmotionBarContainer" class="emotionBarContainer"><div id="negativeEmotionBar" class="emotionBar"></div></div>
   <script>
     const canvas = document.getElementById('solarSystem');
     const ctx = canvas.getContext('2d');
     const cx = canvas.width / 2;
     const cy = canvas.height / 2;
-    const emotionValue = document.getElementById('emotionValue');
-    const emotionBar = document.getElementById('emotionBar');
+    const positiveEmotionValue = document.getElementById('positiveEmotionValue');
+    const positiveEmotionBar = document.getElementById('positiveEmotionBar');
+    const negativeEmotionValue = document.getElementById('negativeEmotionValue');
+    const negativeEmotionBar = document.getElementById('negativeEmotionBar');
 
     const maxDistance = 220;
     const maxSemiMajorAxis = 30.05; // Neptune's semi-major axis in AU
@@ -78,7 +87,8 @@
       radius: Math.random() * 1.5 + 0.5
     }));
 
-    const aspectAngles = [0, Math.PI / 3, Math.PI / 2, (2 * Math.PI) / 3, Math.PI];
+    const positiveAngles = [0, Math.PI / 3, (2 * Math.PI) / 3]; // conjunction, sextile, trine
+    const negativeAngles = [Math.PI / 2, Math.PI]; // square, opposition
     const aspectTolerance = (5 * Math.PI) / 180; // 5 degrees in radians
 
     function angleDifference(a, b) {
@@ -86,8 +96,8 @@
       return diff > Math.PI ? 2 * Math.PI - diff : diff;
     }
 
-    function aspectIntensity(diff) {
-      const minDiff = Math.min(...aspectAngles.map(a => Math.abs(diff - a)));
+    function aspectIntensity(diff, angles) {
+      const minDiff = Math.min(...angles.map(a => Math.abs(diff - a)));
       return Math.max(0, 1 - minDiff / aspectTolerance);
     }
 
@@ -132,7 +142,8 @@
       ctx.fillText('Earth', cx + earth.radius + 2, cy);
 
       // draw planets relative to Earth
-      let emotion = 0;
+      let positiveEmotion = 0;
+      let negativeEmotion = 0;
       planets.forEach(p => {
         p.angle += p.speed;
         const px = Math.cos(p.angle) * p.distance;
@@ -156,11 +167,15 @@
         ctx.fillText(p.name, x + p.radius + 2, y);
 
         const diff = angleDifference(p.angle, earth.angle);
-        emotion += aspectIntensity(diff);
+        positiveEmotion += aspectIntensity(diff, positiveAngles);
+        negativeEmotion += aspectIntensity(diff, negativeAngles);
       });
-      const level = (emotion / planets.length) * 100;
-      emotionBar.style.width = level + '%';
-      emotionValue.textContent = level.toFixed(0);
+      const positiveLevel = (positiveEmotion / planets.length) * 100;
+      const negativeLevel = (negativeEmotion / planets.length) * 100;
+      positiveEmotionBar.style.width = positiveLevel + '%';
+      positiveEmotionValue.textContent = positiveLevel.toFixed(0);
+      negativeEmotionBar.style.width = negativeLevel + '%';
+      negativeEmotionValue.textContent = negativeLevel.toFixed(0);
 
       requestAnimationFrame(draw);
     }


### PR DESCRIPTION
## Summary
- Split single emotion meter into separate positive and negative emotion bars
- Calculate positive and negative influence based on planetary aspect geometry

## Testing
- `npm test 2>&1 | tee /tmp/test.log` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8ee48bf0832fb6b26ba07468b493